### PR TITLE
Fix infinite mention loop bug

### DIFF
--- a/start.php
+++ b/start.php
@@ -73,6 +73,11 @@ function mentions_entity_notification_handler($event, $type, $object) {
 		return NULL;
 	}
 
+	// excludes messages - otherwise an endless loop of notifications occur!
+	if ($object->getSubtype() == "messages") {
+		return NULL;
+	}
+
 	$fields = array(
 		'name', 'title', 'description', 'value'
 	);


### PR DESCRIPTION
Need to exclude messages when processing events otherwise you'll get an infinite loop of mention messages.
