### PR TITLE
Improve compatibility with Elgg 1.9 notification plugins.

### DIFF
--- a/start.php
+++ b/start.php
@@ -181,7 +181,12 @@ function mentions_notification_handler($event, $event_type, $object) {
 						$link,
 					));
 
-					notify_user($user->getGUID(), $owner->getGUID(), $subject, $body);
+					$params = array(
+						'object' => $object,
+						'action' => 'mention',
+					);
+
+					notify_user($user->getGUID(), $owner->getGUID(), $subject, $body, $params);
 				}
 			}
 		}


### PR DESCRIPTION
Passing in the notification object and action e.g. allow the site_notifications plugin to generate a link to the entity where the mentioning took place.
