### PR TITLE
Adds username as data attribute instead of parsing it from the URL

### DIFF
--- a/views/default/css/mentions.php
+++ b/views/default/css/mentions.php
@@ -28,3 +28,15 @@
 	color: white;
 	background-color: #25AAE1;
 }
+
+#mentions-popup {
+	padding: 0;
+}
+
+#mentions-popup .elgg-autocomplete-item {
+	padding: 6px;
+}
+
+#mentions-popup .mentions-autocomplete > li:hover {
+	background-color: #DCDCDC;
+}

--- a/views/default/js/mentions/autocomplete.js
+++ b/views/default/js/mentions/autocomplete.js
@@ -29,7 +29,7 @@ define(function(require) {
 	var handleResponse = function (json) {
 		var userOptions = '';
 		$(json).each(function(key, user) {
-			userOptions += user.label;
+			userOptions += '<li data-username="' + user.desc + '">' + user.label + "</li>";
 		});
 
 		if (!userOptions) {
@@ -38,13 +38,13 @@ define(function(require) {
 			return;
 		}
 
-		$('#mentions-popup > .elgg-body').html(userOptions);
+		$('#mentions-popup > .elgg-body').html('<ul class="mentions-autocomplete">' + userOptions + "</ul>");
 		$('#mentions-popup').removeClass('hidden');
 
-		$('.mentions-popup .elgg-autocomplete-item').bind('click', function(e) {
+		$('.mentions-autocomplete > li').bind('click', function(e) {
 			e.preventDefault();
-			var userUrl = $(this).find('a').first().attr('href');
-			var username = userUrl.split('/').pop();
+
+			var username = $(this).data('username');
 
 			// Remove the partial @username string from the first part
 			newBeforeMention = beforeMention.substring(0, position - current.length);


### PR DESCRIPTION
The autocomplete feature was parsing each username from the link found from the HTML output. The links were removed in Elgg 1.9.6 so the feature got broken. Now the mentions javascript adds the username as data attribute so it can be easily accessed later when selecting a user.

Fixes #24
