### PR TITLE
Makes CKEditor detection more reliable

### DIFF
--- a/start.php
+++ b/start.php
@@ -10,6 +10,8 @@ function mentions_init() {
 	elgg_extend_view('css/elgg', 'css/mentions');
 	elgg_require_js('mentions/autocomplete');
 
+	elgg_register_simplecache_view('js/mentions/config');
+
 	elgg_extend_view('input/longtext', 'mentions/popup');
 	elgg_extend_view('input/plaintext', 'mentions/popup');
 

--- a/views/default/js/mentions/autocomplete.js
+++ b/views/default/js/mentions/autocomplete.js
@@ -9,8 +9,9 @@
 define(function(require) {
 	var $ = require('jquery');
 	var elgg = require('elgg');
+	var config = require('mentions/config');
 
-	if (require.specified('ckeditor')) {
+	if (config.editor == 'ckeditor') {
 		require(['ckeditor'], function(CKEDITOR) {
 			CKEDITOR.on('instanceCreated', function (e) {
 				e.editor.on('contentDom', function(ev) {

--- a/views/default/js/mentions/config.js.php
+++ b/views/default/js/mentions/config.js.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Provides information which editor plugin is used on the site
+ *
+ * Checks which editor plugin (if any) is enabled and provides
+ * the information as an AMD module.
+ */
+
+$plugins = array(
+	'ckeditor',
+	'tinymce',
+);
+
+$editor = 'plaintext';
+foreach ($plugins as $plugin) {
+	if (elgg_is_active_plugin($plugin)) {
+		$editor = $plugin;
+	}
+}
+
+$json = json_encode(array('editor' => $editor));
+
+echo "define($json)";


### PR DESCRIPTION
The `require.specified()` method is unreliable for detecting whether a
module is being used because of the multiple context support. Until
a top level require call claims the define registrations, it is unclear
what context, even the default one, owns it.

See https://github.com/jrburke/requirejs/issues/1305#issuecomment-87924865