### PR TITLE
Moves editor specific parts of the code to separate AMD modules

### DIFF
--- a/start.php
+++ b/start.php
@@ -8,7 +8,9 @@ elgg_register_event_handler('init', 'system', 'mentions_init');
 
 function mentions_init() {
 	elgg_extend_view('css/elgg', 'css/mentions');
-	elgg_require_js('mentions/autocomplete');
+
+	elgg_register_simplecache_view('js/mentions/editor');
+	elgg_require_js('mentions/editor');
 
 	elgg_extend_view('input/longtext', 'mentions/popup');
 	elgg_extend_view('input/plaintext', 'mentions/popup');

--- a/views/default/js/mentions/editor.js.php
+++ b/views/default/js/mentions/editor.js.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Provides different @mentions module depending on the user editor
+ *
+ * Checks which editor plugin (if any) is enabled and provides the
+ * AMD module that takes care of autocompleting @mentions for that
+ * specific editor.
+ */
+
+$plugins = array(
+	'ckeditor',
+	'tinymce',
+);
+
+$editor = 'plaintext';
+foreach ($plugins as $plugin) {
+	if (elgg_is_active_plugin($plugin)) {
+		$editor = $plugin;
+	}
+}
+
+echo elgg_view("js/mentions/editors/{$editor}");

--- a/views/default/js/mentions/editors/ckeditor.js
+++ b/views/default/js/mentions/editors/ckeditor.js
@@ -1,0 +1,35 @@
+/**
+ * CKEditor support for the mentions plugins
+ */
+define(function(require) {
+	var mentions = require('mentions/autocomplete');
+	var CKEDITOR = require('ckeditor');
+
+	CKEDITOR.on('instanceCreated', function (e) {
+		e.editor.on('contentDom', function(ev) {
+			var editable = ev.editor.editable();
+
+			editable.attachListener(editable, 'keyup', function(eve) {
+				// Skip keycodes that cannot be used for entering a username
+			 	if (!mentions.isValidKey(eve.data.$.keyCode)) {
+			 		return;
+			 	}
+
+				content = e.editor.document.getBody().getText();
+				position = ev.editor.getSelection().getRanges()[0].startOffset;
+
+				mentions.autocomplete(content, position, function(newContent) {
+					if (newContent == undefined) {
+						return;
+					}
+
+					// Replace current content with one that
+					// has the autocompleted username
+					e.editor.setData(newContent, function() {
+						this.checkDirty(); // true
+					});
+				});
+			});
+		});
+	});
+});

--- a/views/default/js/mentions/editors/plaintext.js
+++ b/views/default/js/mentions/editors/plaintext.js
@@ -1,0 +1,38 @@
+/**
+ * Mentions support for regular textarea fields
+ */
+define(function(require) {
+	var mentions = require('mentions/autocomplete');
+	var $ = require('jquery');
+
+	var getCursorPosition = function(el) {
+		var pos = 0;
+
+		if ('selectionStart' in el) {
+			pos = el.selectionStart;
+		} else if ('selection' in document) {
+			el.focus();
+			var Sel = document.selection.createRange();
+			var SelLength = document.selection.createRange().text.length;
+			Sel.moveStart('character', - el.value.length);
+			pos = Sel.text.length - SelLength;
+		}
+
+		return pos;
+	};
+
+	$('textarea').bind('keyup', function(e) {
+		// Skip keycodes that cannot be used for entering a username
+	 	if (!mentions.isValidKey(e.which)) {
+	 		return;
+	 	}
+
+		textarea = $(this);
+		content = $(this).val();
+		position = getCursorPosition(this);
+
+		mentions.autocomplete(content, position, function(content) {
+			textarea.val(content);
+		});
+	});
+});

--- a/views/default/js/mentions/editors/tinymce.js
+++ b/views/default/js/mentions/editors/tinymce.js
@@ -1,0 +1,27 @@
+/**
+ * Mentions support for the TinyMCE editor
+ */
+define(function(require) {
+	var mentions = require('mentions/autocomplete');
+
+	// Give some time for the TinyMCE to load
+	setTimeout(function () {
+		for (var i = 0; i < tinymce.editors.length; i++) {
+			var editor = tinymce.editors[i];
+
+			 editor.on('keyup', function (e) {
+				// Skip keycodes that cannot be used for entering a username
+			 	if (!mentions.isValidKey(e.keyCode)) {
+			 		return;
+			 	}
+
+				position = editor.selection.getRng(1).startOffset;
+				content = tinyMCE.activeEditor.getContent({format : 'text'});
+
+				mentions.autocomplete(content, position, function(content) {
+					tinyMCE.activeEditor.setContent(content);
+				});
+			});
+		}
+	}, 500);
+});


### PR DESCRIPTION
I did this quite quickly, so I'm not completely sure if this is the best way to separate concerns.

Tested with CKEditor and regular textarea. Multiline support for CKEditor is broken, but that was the case also before the PR.