### PR TITLE
compatibility for elgg 2.1 and extended_tinymce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Mentions plugin
-================
+Mentions plugin for elgg
+========================
  * Replaces @username with links to the user's profile
  * Sends notifications to users mentioned in posts
+ * compatible with extended_tinyme

--- a/manifest.xml
+++ b/manifest.xml
@@ -2,8 +2,8 @@
 <plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
 	<name>Mentions</name>
 	<id>mentions</id>
-	<author>Core developers</author>
-	<version>1.9</version>
+	<author>Core developers / ura soul</author>
+	<version>2.0</version>
 	<description>Rewrite all @username mentions to link to profile and optionally notify user.</description>
 	<website>http://www.elgg.org/</website>
 	<repository>https://github.com/Elgg/mentions</repository>

--- a/start.php
+++ b/start.php
@@ -12,25 +12,8 @@ function mentions_init() {
 //	elgg_register_simplecache_view('js/mentions/editor');
 //	elgg_require_js('mentions/editor');
 
-	$plugins = array(
-		'ckeditor',
-		'tinymce',
-		'extended_tinymce'
-	);
-
-	$editor = 'plaintext';
-	foreach ($plugins as $plugin) {
-		if (elgg_is_active_plugin($plugin)) {
-			$editor = $plugin;
-		}
-	}
-	if ($editor == 'extended_tinymce')
-		$editor = 'tinymce';
-
-	elgg_require_js("mentions/editors/{$editor}");
-
 	elgg_extend_view('input/longtext', 'mentions/popup');
-	elgg_extend_view('input/plaintext', 'mentions/popup');
+	//elgg_extend_view('input/plaintext', 'mentions/popup');
 
 	//elgg_register_event_handler('pagesetup', 'system', 'mentions_get_views');
 	mentions_get_views();
@@ -50,12 +33,12 @@ function mentions_get_regex() {
 	// @todo this won't work for usernames that must be html encoded.
 	// get all chars with unicode 'letter' or 'mark' properties or a number _ or .,
 	// preceeded by @, and possibly surrounded by word boundaries.
-	return '/[\b]?@([\p{L}\p{M}_\.0-9]+)[\b]?/iu';
+	return '/[\b]?@([\p{L}\p{M}-_\.0-9]+)[\b]?/iu';
 }
 
 function mentions_get_views() {
 	// allow plugins to add additional views to be processed for usernames
-	$views = array('output/longtext', 'river/item');
+	$views = array('output/longtext', 'river/item','object/thewire');
 	$views = elgg_trigger_plugin_hook('get_views', 'mentions', null, $views);
 	foreach ($views as $view) {
 		elgg_register_plugin_hook_handler('view', $view, 'mentions_rewrite');
@@ -72,6 +55,7 @@ function mentions_get_views() {
  */
 function mentions_rewrite($hook, $entity_type, $returnvalue, $params) {
 	$regexp = mentions_get_regex();
+
 	$returnvalue =  preg_replace_callback($regexp, 'mentions_preg_callback', $returnvalue);
 
 	return $returnvalue;

--- a/start.php
+++ b/start.php
@@ -38,7 +38,9 @@ function mentions_get_regex() {
 
 function mentions_get_views() {
 	// allow plugins to add additional views to be processed for usernames
-	$views = array('output/longtext', 'river/item','object/thewire');
+	$views = array('output/longtext');
+	//, 'river/item');
+	//,'object/thewire');
 	$views = elgg_trigger_plugin_hook('get_views', 'mentions', null, $views);
 	foreach ($views as $view) {
 		elgg_register_plugin_hook_handler('view', $view, 'mentions_rewrite');

--- a/start.php
+++ b/start.php
@@ -9,14 +9,11 @@ elgg_register_event_handler('init', 'system', 'mentions_init');
 function mentions_init() {
 	elgg_extend_view('css/elgg', 'css/mentions');
 
-//	elgg_register_simplecache_view('js/mentions/editor');
-//	elgg_require_js('mentions/editor');
-
 	elgg_extend_view('input/longtext', 'mentions/popup');
-	//elgg_extend_view('input/plaintext', 'mentions/popup');
+	elgg_extend_view('input/plaintext', 'mentions/popup');
 
-	//elgg_register_event_handler('pagesetup', 'system', 'mentions_get_views');
 	mentions_get_views();
+	
 	// can't use notification hooks here because of many reasons
 	elgg_register_event_handler('create', 'object', 'mentions_notification_handler');
 	elgg_register_event_handler('create', 'annotation', 'mentions_notification_handler');

--- a/views/default/css/mentions.php
+++ b/views/default/css/mentions.php
@@ -40,3 +40,7 @@
 #mentions-popup .mentions-autocomplete > li:hover {
 	background-color: #DCDCDC;
 }
+
+#mentions-popup h3 {
+	cursor: pointer;
+}

--- a/views/default/js/mentions/autocomplete.js
+++ b/views/default/js/mentions/autocomplete.js
@@ -125,14 +125,16 @@ define(function(require) {
 				// remove @ symbol from current to allow us to use current in a search query
 				current = current.replace('@', '');
 
-				// move mention popup to cursor
+				var options = {success: handleResponse};
+
+				// replace period characters with html encoded equivalent to prevent hanging
+				current = encodeURIComponent(current.replace(/\./g, '&#46;'));
+
+				// reposition mention popup next to cursor
 				positionMentionPopup();
 
 				// show mention popup
 				$('#mentions-popup').removeClass('hidden');
-
-				var options = {success: handleResponse};
-
 				// search for a username matching the current word
 				elgg.get('livesearch?q=' + current + '&match_on=users', options);
 			}

--- a/views/default/js/mentions/editors/tinymce.js
+++ b/views/default/js/mentions/editors/tinymce.js
@@ -8,20 +8,20 @@ define(function(require) {
 	setTimeout(function () {
 		for (var i = 0; i < tinymce.editors.length; i++) {
 			var editor = tinymce.editors[i];
-
 			 editor.on('keyup', function (e) {
 				// Skip keycodes that cannot be used for entering a username
 			 	if (!mentions.isValidKey(e.keyCode)) {
 			 		return;
 			 	}
+				var sel = tinymce.activeEditor.getWin().getSelection(), // current selection
+						position = sel.anchorOffset, // get caret start position
+						node = sel.anchorNode; // get the current #text node
 
-				position = editor.selection.getRng(1).startOffset;
-				content = tinyMCE.activeEditor.getContent({format : 'text'});
-
-				mentions.autocomplete(content, position, function(content) {
-					tinyMCE.activeEditor.setContent(content);
+				mentions.autocomplete(node, position, function(content) {
+					tinymce.activeEditor.selection.select(tinymce.activeEditor.selection.getNode(),true);
+					tinymce.activeEditor.selection.setContent(content, {format : 'raw'});
 				});
 			});
 		}
-	}, 500);
+	}, 5000);
 });

--- a/views/default/mentions/popup.php
+++ b/views/default/mentions/popup.php
@@ -1,9 +1,25 @@
 <?php
 
+$plugins = array(
+	'ckeditor',
+	'tinymce',
+	'extended_tinymce'
+);
+
+$editor = 'plaintext';
+foreach ($plugins as $plugin) {
+	if (elgg_is_active_plugin($plugin)) {
+		$editor = $plugin;
+	}
+}
+if ($editor == 'extended_tinymce')
+	$editor = 'tinymce';
+
+elgg_require_js("mentions/editors/{$editor}");
+
 $vars = array(
 	'class' => 'mentions-popup hidden',
 	'id' => 'mentions-popup',
 );
 
 echo elgg_view_module('popup', '', elgg_view('graphics/ajax_loader', array('hidden' => false)), $vars);
-


### PR DESCRIPTION
this version of the code includes functions to grab the cursor's absolute location in tinymce (tinymce_extended) and so places the popup menu in the correct location. i have also fixed other bugs relating to usernames with hyphens and lookups with full stops in them.
this does not yet appear to work with plaintext fields and i haven't put any specific code in to improve that aspect. i have not tested ckeditor at all.
